### PR TITLE
Support transforms with multiple arguments

### DIFF
--- a/HOPS/GF/Transform.hs
+++ b/HOPS/GF/Transform.hs
@@ -119,12 +119,12 @@ dirichlet _ = V.empty
 dirichleti :: Vector Rat -> Vector Rat
 dirichleti f = foldl' upd (V.replicate (length f) 0) [1..length f]
   where
-    upd g 1 = g // [(0, 1 / (V.head f))]
+    upd g 1 = g // [(0, 1 / V.head f)]
     upd g n = let s = sum [ (f ! (n `div` d - 1)) * (g ! (d - 1))
                           | d <- [1..n-1]
                           , n `mod` d == 0
                           ]
-              in g // [(n-1, -s / (V.head f))]
+              in g // [(n-1, -s / V.head f)]
 
 
 restrictToPrefix :: Int -> Vector Rat -> Vector Rat

--- a/HOPS/GF/Transform.hs
+++ b/HOPS/GF/Transform.hs
@@ -9,7 +9,7 @@
 --
 
 module HOPS.GF.Transform
-    ( Transform
+    ( Transform(..)
     , lookupTransform
     , transforms
     ) where
@@ -17,7 +17,9 @@ module HOPS.GF.Transform
 import GHC.TypeLits
 import Data.Proxy
 import Data.Ratio
-import Data.Vector (Vector, (!))
+import Data.Maybe
+import Data.List (foldl')
+import Data.Vector (Vector, (!), (!?), (//))
 import qualified Data.Vector as V
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
@@ -25,8 +27,10 @@ import Data.ByteString.Char8 (ByteString)
 import HOPS.GF.Series
 import HOPS.Utils.Matrix
 
--- | A `Transform` takes a `Series` to another `Series`.
-type Transform n = Series n -> Series n
+-- | A `Transform` takes zero or more `Series` to another `Series`.
+data Transform n = Transform1 (Series n -> Series n)
+                 | TransformAny ([Series n] -> Series n)
+                 | TransformK Int ([Series n] -> Series n)
 
 x :: KnownNat n => Series n
 x = xpow 1
@@ -36,6 +40,9 @@ facSeries = series (Proxy :: Proxy n) $ scanl (*) 1 (map fromIntegral [1::Int ..
 
 lift :: (Vector Rat -> Vector Rat) -> Series n -> Series n
 lift f (Series cs) = Series (f cs)
+
+liftAny :: ([Vector Rat] -> Vector Rat) -> [Series n] -> Series n
+liftAny f ss = Series (f [ cs | (Series cs) <- ss ])
 
 uncons :: Vector a -> Maybe (a, Vector a)
 uncons u
@@ -72,12 +79,12 @@ trisect2 u =
       Nothing      -> V.empty
       Just (_, u') -> V.snoc (trisect1 u') Indet
 
-shiftLeft :: Transform n
+shiftLeft :: Series n -> Series n
 shiftLeft f@(Series u)
     | V.null u  = f
     | otherwise = Series $ V.snoc (V.tail u) Indet
 
-shiftRight :: Transform n
+shiftRight :: Series n -> Series n
 shiftRight f@(Series u)
     | V.null u  = f
     | otherwise = Series $ V.cons 1 (V.init u)
@@ -99,31 +106,38 @@ mobiusFun a b
 mu :: Integer -> Integer
 mu = mobiusFun 1
 
-mobius :: Vector Rat -> Vector Rat
-mobius u = V.generate (V.length u) (\i -> term (i+1))
+-- The number theoretical Dirichlet convolution
+dirichlet :: [Vector Rat] -> Vector Rat
+dirichlet [f,g] = V.generate (max (V.length f) (V.length g)) (\i -> term (i+1))
   where
-    term n = sum [ Val m * (u ! (k-1))
-                 | k <- [1..n]
-                 , let m = mu (fromIntegral (n `div` k)) % 1
-                 , n `rem` k == 0
+    term n = sum [ fromMaybe 0 ((*) <$> f !? (n `div` d - 1) <*> g !? (d - 1))
+                 | d <- [1..n]
+                 , n `mod` d == 0
                  ]
+dirichlet _ = V.empty
 
-mobiusi :: Vector Rat -> Vector Rat
-mobiusi u = V.generate (V.length u) (\i -> term (i+1))
+dirichleti :: Vector Rat -> Vector Rat
+dirichleti f = foldl' upd (V.replicate (length f) 0) [1..length f]
   where
-    term n = sum [ u ! (k-1) | k <- [1..n], n `rem` k == 0 ]
+    upd g 1 = g // [(0, 1 / (V.head f))]
+    upd g n = let s = sum [ (f ! (n `div` d - 1)) * (g ! (d - 1))
+                          | d <- [1..n-1]
+                          , n `mod` d == 0
+                          ]
+              in g // [(n-1, -s / (V.head f))]
+
 
 restrictToPrefix :: Int -> Vector Rat -> Vector Rat
 restrictToPrefix n = V.imap $ \i c -> if i < n then c else Indet
 
-euler :: KnownNat n => Transform n
+euler :: KnownNat n => Series n -> Series n
 euler f =
     lift (restrictToPrefix (length cs)) $ shiftLeft (1 / product gs)
   where
     cs = map Val (rationalPrefix f)
     gs = zipWith (\k c -> (1 - xpow k) ^! c) [1::Int ..] cs
 
-euleri :: Transform n
+euleri :: Series n -> Series n
 euleri (Series u) = Series $ V.generate (V.length u) (\i -> term (i+1))
   where
     f 1 = u ! 0
@@ -135,14 +149,14 @@ euleri (Series u) = Series $ V.generate (V.length u) (\i -> term (i+1))
                      , n `rem` d == 0
                      ]
 
-weight :: KnownNat n => Transform n
+weight :: KnownNat n => Series n -> Series n
 weight f =
     lift (restrictToPrefix (length cs)) $ shiftLeft (product gs)
   where
     cs = map Val (rationalPrefix f)
     gs = zipWith (\n c -> (1 + xpow n) ^! c) [1::Int ..] cs
 
-mask :: KnownNat n => Transform n
+mask :: KnownNat n => Series n -> Series n
 mask = series (Proxy :: Proxy n) . tail . scanl h 0 . coeffList
   where
     h DZ _      = DZ
@@ -150,7 +164,7 @@ mask = series (Proxy :: Proxy n) . tail . scanl h 0 . coeffList
     h _ Indet   = Indet
     h _ DZ      = DZ
 
-multiset :: KnownNat n => Transform n
+multiset :: KnownNat n => Series n -> Series n
 multiset f
     | constant f /= 0 = infty
     | otherwise       = mask f + 1 / product gs
@@ -158,7 +172,7 @@ multiset f
     cs = rationalPrefix f
     gs = zipWith (\k c -> (1 - xpow k) ^! Val c) [1::Int ..] (tail cs)
 
-powerset :: KnownNat n => Transform n
+powerset :: KnownNat n => Series n -> Series n
 powerset f
     | constant f /= 0 = infty
     | otherwise       = mask f + product gs
@@ -166,7 +180,7 @@ powerset f
     cs = rationalPrefix f
     gs = zipWith (\k c -> (1 + xpow k) ^! Val c) [1::Int ..] (tail cs)
 
-ccycle :: KnownNat n => Transform n
+ccycle :: KnownNat n => Series n -> Series n
 ccycle f = sum $ map g [1::Int .. precision f - 1]
   where
     g k = fromRational (fromIntegral (totient k) % fromIntegral k) *
@@ -177,7 +191,7 @@ totient 1 = 1
 totient a = length $ filter (\k -> gcd a k == 1) [1..a-1]
 
 -- T019: a[j+2]-2*a[j+1]+a[j] where a[j] = j-th term of the sequence
-t019 :: KnownNat n => Transform n
+t019 :: KnownNat n => Series n -> Series n
 t019 f = ((1-x)*(1-x)*f + (2*a0 - a1)*x - a0) / (x*x)
   where
     v  = coeffVector f
@@ -185,11 +199,11 @@ t019 f = ((1-x)*(1-x)*f + (2*a0 - a1)*x - a0) / (x*x)
     a1 = polynomial (Proxy :: Proxy n) [v!1]
 
 -- The Boustrophedon transform
-bous :: KnownNat n => Transform n
+bous :: KnownNat n => Series n -> Series n
 bous f = laplace (laplacei f * (sec x + tan x))
 
 -- The inverse Boustrophedon transform
-bousi :: KnownNat n => Transform n
+bousi :: KnownNat n => Series n -> Series n
 bousi f = laplace (laplacei f / (sec x + tan x))
 
 hankel :: Vector Rat -> Vector Rat
@@ -199,14 +213,15 @@ hankel v = V.generate n $ \i -> det (hankelN (i+1))
     hankelN i = V.take i $ V.map (V.take i) hankelMatrix
     hankelMatrix = V.iterateN n (\u -> V.snoc (V.tail u) Indet) v
 
-laplace :: KnownNat n => Transform n
+laplace :: KnownNat n => Series n -> Series n
 laplace f = f .* facSeries
 
-laplacei :: KnownNat n => Transform n
+laplacei :: KnownNat n => Series n -> Series n
 laplacei f = f ./ facSeries
 
 associations :: KnownNat n => [(ByteString, Transform n)]
 associations =
+  map (Transform1 <$>)
     [ ("ABS",        \(Series v) -> Series (V.map abs v))
     , ("BARRY1",     \f -> 1 / (1 - x - x*x*f)) -- Named after Paul Barry
     , ("BARRY2",     \f -> 1 / (1 + x + x*x*f)) -- Named after Paul Barry
@@ -222,6 +237,7 @@ associations =
     , ("CYC",        ccycle)
     , ("DIFF",       lift finDiff)
     , ("D",          derivative)
+    , ("DIRICHLETi", lift dirichleti)
     , ("EULERi",     euleri)
     , ("EULER",      euler)
     , ("EXP",        \f -> shiftLeft $ laplace (exp (laplacei (x*f))))
@@ -233,8 +249,8 @@ associations =
     , ("LAH",        \f -> laplace(laplacei f `o` (x/(1-x))))
     , ("LEFT",       shiftLeft)
     , ("LOG",        \f -> shiftLeft $ laplace(log (1 + laplacei (x*f))))
-    , ("MOBIUSi",    lift mobiusi)
-    , ("MOBIUS",     lift mobius)
+    , ("MOBIUSi",    \f -> liftAny dirichlet [1/(1-x), f])
+    , ("MOBIUS",     \f -> liftAny dirichlet [lift dirichleti (1/(1-x)), f])
     , ("MSET",       multiset)
     , ("PARTITION",  multiset . rseq)
     , ("POINT",      \f -> x*derivative f)
@@ -270,6 +286,21 @@ associations =
     , ("cos",        cos)
     , ("tan",        tan)
     , ("sec",        sec)
+    , ("neg",        negate)
+    , ("fac",        fac)
+    ]
+  ++ map (TransformK 2 <$>)
+    [ ("add",        \[f,g] -> (+) f g)
+    , ("sub",        \[f,g] -> (-) f g)
+    , ("mul",        \[f,g] -> (*) f g)
+    , ("div",        \[f,g] -> (/) f g)
+    , ("bdp",        \[f,g] -> blackDiamond f g)
+    , ("pow",        \[f,g] -> (**) f g)
+    , ("comp",       \[f,g] -> o f g)
+    , ("coef",       \[f,g] -> (?) f g)
+    , ("ptmul",      \[f,g] -> (.*) f g)
+    , ("ptdiv",      \[f,g] -> (./) f g)
+    , ("DIRICHLET",  liftAny dirichlet)
     ]
 
 dispatch :: KnownNat n => Map ByteString (Transform n)

--- a/docs/language.md
+++ b/docs/language.md
@@ -132,7 +132,7 @@ expr1 = expr1 ("*" | "/" | ".*" | "./") expr1 | expr2
 
 expr2 = ("-" | "+") expr2 | expr3 "!" | expr3 "^" expr3 | expr3 "@" expr3 | expr3 "?" expr3 |expr3
 
-expr3 = "x" | anum | tag | name | lit | "{" { terms } "}" | "[" { terms } "]" | name "(" expr3 ")" | expr0
+expr3 = "x" | anum | tag | name | lit | "{" { terms } "}" | "[" { terms } "]" | name "(" expr0 { "," expr0 }  ")" | name expr3 | "(" expr0 ")"
 
 lit = int
 


### PR DESCRIPTION
This adds support for transforms with multiple arguments, e.g. `f = 1+x*DIRICHLET(f,{1,...})`.

It's still a work in progress (although things seem to work). In particular: 
- [x] Some tests seem to be failing.
- [ ] Tests should be added for the changes.
- [x] Documentation (e.g. grammar) needs to be updated.
- [x] Make sure "Hops as a library" isn't broken.
- [x] Possibly clean up the implementation.